### PR TITLE
Bump reconcile interval to 10 minutes

### DIFF
--- a/flux-system/gotk-sync.yaml
+++ b/flux-system/gotk-sync.yaml
@@ -5,7 +5,7 @@ metadata:
   name: flux-system
   namespace: flux-system
 spec:
-  interval: 1m0s
+  interval: 10m0s
   ref:
     branch: main
   secretRef:
@@ -19,7 +19,7 @@ metadata:
   name: flux-system
   namespace: flux-system
 spec:
-  interval: 1m0s
+  interval: 10m0s
   path: ./
   prune: true
   sourceRef:


### PR DESCRIPTION
Reconciling the Git repository and flux-system kustomization every 1 minute is probably too much... relax a bit by reconciling every 10 minutes.
