### PR TITLE
Add slack-api-url secret

### DIFF
--- a/secrets/slack-api-url.yaml
+++ b/secrets/slack-api-url.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: slack-api-url
+    namespace: flux-system
+stringData:
+    slack_api_url: ENC[AES256_GCM,data:D4NVtRWZcIda6n8oJQrPT/hUjd/zANn4L/UnQkQ1THRImVkKz03IjlTuV7GR+8VMj10oLm0XIHs9+jT5+LvXfQ58ieR473S8oVr0yUnJphrW,iv:1rVmg9M9yi+vrJN4XW7B2f7QO1mj9Fm0YjeArnh35uE=,tag:HwXdiPAlGNnkRzEFhWaASQ==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1a2e8j4zajj69sd9atf88quglm6ghhsetxhqtftfvvl7az90zmytqzyt9cc
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZNDQvSk1CZGlWWmJsU3Ji
+            YlRnSVVJbUZacFFCUjRQMWIxc1FuNVlmSndzCnBNNnB2L0s4ZlZDSUVPeVVEWVkv
+            NWRLT0lJVHpqdDhUQUhLajQ5OWMra3cKLS0tIHRuOEI1aXJjUDRaQ3Vjai9qSkoz
+            eVg0aUowa0FzTTJjL3BUSXZMYUxINjgKWwGgr9gbtg9UXsJJtEpPO/WYD/2WUHNO
+            HpMhy237WH8wRDFztP/0GbVlCg4fj0Qf45Giwpag9o9xdpd6vC9qWw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2022-09-04T10:36:47Z"
+    mac: ENC[AES256_GCM,data:mHOt06GNyd5smgh6d0B0efub/5QzgmIgO0KFacFtwTEQHsQUQBZ7O8KGAvftDAyp5Jg8UBb256N56Twe8hIPT5kqqULB1O+rC1eT0ehfMVS9hCMB1rSD2AKReMaNWFMZsLvDPJJeTOvfns5bERWocle6xzEX/Pf3LB0Ejwvk/Ok=,iv:JPGOcAS+j1pN29hYcoroGjIiDodTi5LuKk6FnPwy53U=,tag:gZoGzkCaboP8/aYh0chT8g==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.7.3


### PR DESCRIPTION
The secret was edited as-is (in clear-text) and then encrypted in-place via:

```
$ sops --encrypt --in-place slack-api-url.yaml
```

(Given that we have a `.sops.yaml` file sops already pick up the right public key to encrypt it without asking anything.)

Please note that this is completely untested!
