### PR TITLE
Configure alertmanager to send alerts to Slack

### DIFF
--- a/infrastructure/kube-prometheus-stack/release.yaml
+++ b/infrastructure/kube-prometheus-stack/release.yaml
@@ -22,7 +22,40 @@ spec:
   targetNamespace: prometheus
   upgrade:
     crds: CreateReplace
+  valuesFrom:
+    - kind: Secret
+      name: slack-api-url
+      valuesKey: slack_api_url
+      targetPath: alertmanager.config.global.slack_api_url
   values:
+    alertmanager:
+      config:
+        route:
+          group_by: ['namespace']
+          group_wait: 30s
+          group_interval: 5m
+          repeat_interval: 12h
+          receiver: 'null'
+          routes:
+            - receiver: 'null'
+              matchers:
+                - alertname =~ "InfoInhibitor|Watchdog"
+            - receiver: 'slack'
+        receivers:
+          - name: 'null'
+          - name: 'slack'
+            slack_configs:
+              - send_resolved: true
+                channel: '#rpi-alerts'
+                title: '[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }}{{ if .CommonLabels.job }} for {{ .CommonLabels.job }}{{end}}'
+                text: |-
+                  {{ range .Alerts }}
+                    *Alert:* {{ .Annotations.summary }} - `{{ .Labels.severity }}`
+                    *Description:* {{ .Annotations.description }}
+                    *Details:*
+                    {{ range .Labels.SortedPairs }} • *{{ .Name }}:* `{{ .Value }}`
+                    {{ end }}
+                  {{ end }}
     defaultRules:
       rules:
         kubeControllerManager: false


### PR DESCRIPTION
Adjust the configuration - based on default Helm values, except for slack_configs that was based on work done on faire.ai - to send alerts to the `#rpi-alerts` Slack channel (in a private Slack workplace).

The Slack API URL is picked up via the slack-api-url and injected via targetPath to set it as the default Slack webhook URL.
