### PR TITLE
Disable etcd and etcd scraping

### DIFF
--- a/infrastructure/kube-prometheus-stack/release.yaml
+++ b/infrastructure/kube-prometheus-stack/release.yaml
@@ -58,6 +58,7 @@ spec:
                   {{ end }}
     defaultRules:
       rules:
+        etcd: false
         kubeControllerManager: false
         kubeProxy: false
         kubeScheduler: false
@@ -66,6 +67,8 @@ spec:
       forceDeployDashboards: true
       forceDeployDatasources: true
     kubeControllerManager:
+      enabled: false
+    kubeEtcd:
       enabled: false
     kubeProxy:
       enabled: false


### PR DESCRIPTION
k3s does not provide any etcd metrics.

Noticed via Grafana etcd dashboard and double-checked via Prometheus Service Discovery page (`serviceMonitor/prometheus/kube-prometheus-stack-kube-etcd/0` has 0 active targets).
