### PR TITLE
Disable Grafana analytics

### DIFF
--- a/infrastructure/grafana/release.yaml
+++ b/infrastructure/grafana/release.yaml
@@ -25,6 +25,7 @@ spec:
       analytics:
         check_for_plugin_updates: false
         check_for_updates: false
+        enable_feedback_links: false
         reporting_enabled: false
       auth.anonymous:
         enabled: true


### PR DESCRIPTION
This PR disable several Grafana analytics that should be not needed and/or not desiderable.
