### PR TITLE
Enable Prometheus ServiceMonitor for promtail

### DIFF
--- a/infrastructure/promtail/release.yaml
+++ b/infrastructure/promtail/release.yaml
@@ -27,3 +27,8 @@ spec:
       enabled: true
       labels:
         release: kube-prometheus-stack
+      metricRelabelings:
+        - action: drop
+          regex: promtail_(file_bytes_total|read_bytes_total|read_lines_total)
+          sourceLabels:
+            - __name__


### PR DESCRIPTION
This PR enable Prometheus ServiceMonitor for `promtail` and adjust it to drop possible high cardinality metrics from it.
