### PR TITLE
Enable alerting and recording rules for Loki

### DIFF
--- a/infrastructure/loki/kustomization.yaml
+++ b/infrastructure/loki/kustomization.yaml
@@ -2,3 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - release.yaml
+configMapGenerator:
+  - name: rules
+    namespace: loki
+    files:
+      - rules/general.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/infrastructure/loki/release.yaml
+++ b/infrastructure/loki/release.yaml
@@ -42,5 +42,13 @@ spec:
         labels:
           release: kube-prometheus-stack
     singleBinary:
+      extraVolumeMounts:
+        - name: rules
+          mountPath: /var/loki/rules/fake
+      extraVolumes:
+        - name: rules
+          configMap:
+            name: rules
+            defaultMode: 0444
       persistence:
         size: 1Gi

--- a/infrastructure/loki/rules/general.yaml
+++ b/infrastructure/loki/rules/general.yaml
@@ -1,0 +1,17 @@
+groups:
+  - name: general
+    rules:
+      - alert: Watchdog
+        annotations:
+          description: |
+            This is an alert meant to ensure that the entire alerting pipeline is functional.
+            This alert is always firing, therefore it should always be firing in Alertmanager
+            and always fire against a receiver. There are integrations with various notification
+            mechanisms that send a notification when this alert is not firing. For example the
+            "DeadMansSnitch" integration in PagerDuty.
+          runbook_url: https://runbooks.prometheus-operator.dev/runbooks/general/watchdog
+          summary: An alert that should always be firing to certify that Alertmanager
+            is working properly.
+        expr: 1
+        labels:
+          severity: none


### PR DESCRIPTION
This PR instruct the Loki rules to point to the kube-prometheus-stack Alertmanager, add a `loki="loki/loki"` label to the Loki alert rules and finally enable alerting and recording rules via a `rules` ConfigMap.

An always triggering `Watchdog` alert was added completely similar to the Prometheus one.

This permits to possibly add more rules without restarting Loki.
