### PR TITLE
Switch to use options per configMapGenerator

### DIFF
--- a/infrastructure/kube-prometheus-stack/kustomization.yaml
+++ b/infrastructure/kube-prometheus-stack/kustomization.yaml
@@ -5,6 +5,8 @@ resources:
 configMapGenerator:
   - name: consoles
     namespace: prometheus
+    options:
+      disableNameSuffixHash: true
     files:
       - consoles/index.html.example
       - consoles/node-cpu.html
@@ -13,5 +15,3 @@ configMapGenerator:
       - consoles/node.html
       - consoles/prometheus-overview.html
       - consoles/prometheus.html
-generatorOptions:
-  disableNameSuffixHash: true

--- a/infrastructure/loki/kustomization.yaml
+++ b/infrastructure/loki/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 configMapGenerator:
   - name: rules
     namespace: loki
+    options:
+      disableNameSuffixHash: true
     files:
       - rules/general.yaml
-generatorOptions:
-  disableNameSuffixHash: true


### PR DESCRIPTION
generatorOptions affects all configMapGenerator-s and... at least for the disableNameSuffixHash it is probably not nice set it for all configMapGenerator in the same kustomization (probably pretty error-prone!).

Avoid it by using options.

No functional change.
