### PR TITLE
Update to kubeconform 0.4.14

### DIFF
--- a/.github/workflows/kubeconform.yaml
+++ b/.github/workflows/kubeconform.yaml
@@ -7,7 +7,7 @@ name: Validate Kubernetes configuration files
   pull_request:
 
 env:
-  KUBECONFORM_VERSION: "v0.4.13"
+  KUBECONFORM_VERSION: "v0.4.14"
 
 jobs:
   validate:


### PR DESCRIPTION
This PR removes no longer used `{KUSTOMIZE,KUBECONFORM}_FLAGS` and update to kubeconform 0.4.14 (latest stable release).
