### PR TITLE
Update to loki chart version 3.2.0

### DIFF
--- a/infrastructure/loki/release.yaml
+++ b/infrastructure/loki/release.yaml
@@ -12,7 +12,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: grafana
-      version: 3.0.1
+      version: 3.2.0
   install:
     createNamespace: true
   interval: 10m0s


### PR DESCRIPTION
Changes:
3.2.0
 [CHANGE] Bump Grafana Enterprise Logs version to v1.5.2

3.1.0
 [FEATURE] Loki canary and GEL token provisioner added. The GEL
 token provisioner will provision a tenant and token to be used by
 the self-monitoring features (including the canary), as well as any
 additional tenants specified. A k8s secret will be created with a
 read and write token for each additional tenant specified.

3.0.4
 [CHANGE] Default minio replicas to 1 node with 2 drives. The old
 config used the default, which was 16 nodes with 1 drive each.
 [BUGFIX] Minio subchart values accessKey and secretKey were removed
 in the new chart and replaced with rootUser and rootPassword.
 [CHANGE] The tokengen job no longer creates a grafana-token, as the
 base64 encoding was not working in a Grafana Enterprise GEL plugin
 installation.
