### PR TITLE
Add status field to each single alert

### DIFF
--- a/infrastructure/kube-prometheus-stack/release.yaml
+++ b/infrastructure/kube-prometheus-stack/release.yaml
@@ -52,6 +52,7 @@ spec:
                   {{ range .Alerts }}
                     *Alert:* {{ .Annotations.summary }} - `{{ .Labels.severity }}`
                     *Description:* {{ .Annotations.description }}
+                    *Status:* {{ .Status }}
                     *Details:*
                     {{ range .Labels.SortedPairs }} • *{{ .Name }}:* `{{ .Value }}`
                     {{ end }}


### PR DESCRIPTION
In the notification there are actually:

- Status (of Data): this is the "global" status, it is firing if at least one alert is firing; resolved otherwise
- Status (of Alert): can be fired or resolved

When multiple alerts are grouped together and some alert are firing and other are resolved without having a status field for each single alert we could not easily spot which of them are actually resolved.
