### PR TITLE
Explicitly pass -kubernetes-version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,9 @@ CURL = curl
 FLUX_CRD_SCHEMAS_URL = https://github.com/fluxcd/flux2/releases/latest/download/crd-schemas.tar.gz
 FLUX_CRD_SCHEMAS_TMPDIR = /tmp/flux-crd-schemas
 FLUX_CRD_SCHEMAS_TMPFILE = $(FLUX_CRD_SCHEMAS_TMPDIR)/flux-crd-schemas.tar.gz
+KUBERNETES_VERSION = 1.24.4
 KUBECONFORM = kubeconform
-KUBECONFORM_FLAGS = -ignore-missing-schemas -strict -schema-location default -schema-location $(FLUX_CRD_SCHEMAS_TMPDIR) -verbose
+KUBECONFORM_FLAGS = -ignore-missing-schemas -strict -kubernetes-version $(KUBERNETES_VERSION) -schema-location default -schema-location $(FLUX_CRD_SCHEMAS_TMPDIR) -verbose
 KUSTOMIZE = kustomize
 KUSTOMIZE_FLAGS = --load-restrictor=LoadRestrictionsNone --reorder=legacy
 


### PR DESCRIPTION
Pass the Kubernetes version of the server to avoid accidentally omitting possible schema validation.

By default kubeconform pick up the master Kubernetes version. If an API gets deleted but we are still on an old Kubernetes version such resources will be no longer validated against schema.
