### PR TITLE
Update promtail to Helm chart version 6.6.2

### DIFF
--- a/infrastructure/promtail/release.yaml
+++ b/infrastructure/promtail/release.yaml
@@ -12,7 +12,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: grafana
-      version: 6.3.0
+      version: 6.6.2
   install:
     createNamespace: true
   interval: 10m0s


### PR DESCRIPTION
This PR updates to latest promtail Helm chart version.

# Changes
Unfortunately no changelog is provided by upstream but from the commits:

- fixed PSP Kubernetes 1.25 deprecations
- add support for different HTTP prefix
- permit to set limits_config
- add support for extraContainers
