### PR TITLE
Update Loki Helm chart to version 3.6.0

### DIFF
--- a/infrastructure/loki/release.yaml
+++ b/infrastructure/loki/release.yaml
@@ -54,3 +54,7 @@ spec:
             defaultMode: 0444
       persistence:
         size: 1Gi
+    test:
+      # XXX: Needs loki canary, i.e. incompatible with
+      # XXX: `loki.monitoring.selfMonitoring.lokiCanary.enabled: false'
+      enabled: false

--- a/infrastructure/loki/release.yaml
+++ b/infrastructure/loki/release.yaml
@@ -28,8 +28,6 @@ spec:
         alertmanager_url: http://kube-prometheus-stack-alertmanager.prometheus.svc.cluster.local:9093
         external_labels:
           loki: "loki/loki"
-        storage:
-          type: 'local'
       storage:
         type: 'filesystem'
     monitoring:

--- a/infrastructure/loki/release.yaml
+++ b/infrastructure/loki/release.yaml
@@ -12,7 +12,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: grafana
-      version: 3.2.0
+      version: 3.6.0
   install:
     createNamespace: true
   interval: 10m0s


### PR DESCRIPTION
This PR updates Loki Helm chart to version 3.6.0 and adjust Helm values accordingly.
