### PR TITLE
Update Loki to Helm chart version 3.6.1

### DIFF
--- a/infrastructure/loki/release.yaml
+++ b/infrastructure/loki/release.yaml
@@ -12,7 +12,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: grafana
-      version: 3.6.0
+      version: 3.6.1
   install:
     createNamespace: true
   interval: 10m0s


### PR DESCRIPTION
Changes:
Reintroduce PrometheusRule alerts that were accidentally empty in 3.6.0.
