### PR TITLE
Update to kube-prometheus-stack chart 43.2.1

### DIFF
--- a/infrastructure/kube-prometheus-stack/release.yaml
+++ b/infrastructure/kube-prometheus-stack/release.yaml
@@ -12,7 +12,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: prometheus-community
-      version: 39.11.0
+      version: 43.2.1
   install:
     crds: Create
     createNamespace: true


### PR DESCRIPTION
# Changes:
Update to Prometheus-Operator v0.61.1, Prometheus to v2.40.5 and Thanos
to v0.29.0.
