### PR TITLE
Update to grafana Helm chart 6.49.0

### DIFF
--- a/infrastructure/grafana/release.yaml
+++ b/infrastructure/grafana/release.yaml
@@ -12,7 +12,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: grafana
-      version: 6.36.2
+      version: 6.49.0
   install:
     createNamespace: true
   interval: 10m0s


### PR DESCRIPTION
# Changes:
Update to Grafana 9.3.1.

Add support to deploy Grafana alerts via `sidecar.alerts.*`.
