### PR TITLE
Update to kube-prometheus-stack chart 44.2.1

### DIFF
--- a/infrastructure/kube-prometheus-stack/release.yaml
+++ b/infrastructure/kube-prometheus-stack/release.yaml
@@ -12,7 +12,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: prometheus-community
-      version: 43.2.1
+      version: 44.2.1
   install:
     crds: Create
     createNamespace: true


### PR DESCRIPTION
# Changes:
Update to Prometheus Operator v0.62.0, Prometheus to to v2.41.0 and Thanos to v0.30.1.

Should also enable to use Discord receiver in Alertmanager.
