### PR TITLE
Stop ignoring missing schemas and just ignore CRD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ FLUX_CRD_SCHEMAS_TMPDIR = /tmp/flux-crd-schemas
 FLUX_CRD_SCHEMAS_TMPFILE = $(FLUX_CRD_SCHEMAS_TMPDIR)/flux-crd-schemas.tar.gz
 KUBERNETES_VERSION = 1.25.4
 KUBECONFORM = kubeconform
-KUBECONFORM_FLAGS = -ignore-missing-schemas -strict -kubernetes-version $(KUBERNETES_VERSION) -schema-location default -schema-location $(FLUX_CRD_SCHEMAS_TMPDIR) -verbose
+KUBECONFORM_FLAGS = -strict -kubernetes-version $(KUBERNETES_VERSION) -schema-location default -schema-location $(FLUX_CRD_SCHEMAS_TMPDIR) -skip CustomResourceDefinition -verbose
 KUSTOMIZE = kustomize
 KUSTOMIZE_FLAGS = --load-restrictor=LoadRestrictionsNone --reorder=legacy
 


### PR DESCRIPTION
Ignoring missing schemas can ends up ignoring also a lot of resource validation as it happened accidentally previously for Flux until commit 7bfa7ff.

Right now the only problematic resources are the CustomResourceDefinition. Datree has a CRDs-catalog that can be used in such cases that we should probably start using. For the moment though, just skip them as it was until now.
