### PR TITLE
Add a yamllint target and yamllint GitHub Actions workflow

### DIFF
--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -1,0 +1,18 @@
+name: Lint YAML files
+
+'on':
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  validate:
+    name: Lint YAML files
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Lint YAML files
+        run: |
+          make yamllint

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ KUBECONFORM = kubeconform
 KUBECONFORM_FLAGS = -strict -kubernetes-version $(KUBERNETES_VERSION) -schema-location default -schema-location $(FLUX_CRD_SCHEMAS_TMPDIR) -skip CustomResourceDefinition -verbose
 KUSTOMIZE = kustomize
 KUSTOMIZE_FLAGS = --load-restrictor=LoadRestrictionsNone --reorder=legacy
+YAMLLINT = yamllint
 
 all: validate
 
@@ -40,3 +41,7 @@ validate: crds
 			$(KUSTOMIZE) build $(KUSTOMIZE_FLAGS) $$dirname | \
 			$(KUBECONFORM) $(KUBECONFORM_FLAGS); \
 		done
+
+yamllint:
+	@echo "Linting YAML files"
+	@$(YAMLLINT) --config-data relaxed --no-warnings .


### PR DESCRIPTION
Add a yamllint target in order to run [yamllint](https://yamllint.readthedocs.io/) in relaxed mode and only reports errors.

There are several errors that could be catched by yamllint like for example the ones catched by [key-duplicates](https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.key_duplicates) rule that would ends up unnoticed otherwise.

---

This PR also add a yamllint GitHub Actions workflow that will be run at each push and PR so such checks are properly enforced.
