### PR TITLE
Update GitRepository to source.toolkit.fluxcd.io/v1

### DIFF
--- a/clusters/rpi/flux-system/gotk-sync.yaml
+++ b/clusters/rpi/flux-system/gotk-sync.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
   name: flux-system


### PR DESCRIPTION
No deprecated fields should be used so all of them should be fine as is without any adjustments.

Mechanically done via:

```console
sed -i -e '/^apiVersion:/s;source.toolkit.fluxcd.io/v1beta2;source.toolkit.fluxcd.io/v1;' `ag -l '^kind: GitRepository'`
```

Part of updating to Flux 2.0.0.

---

Based on notes in <https://github.com/fluxcd/flux2/releases/tag/v2.0.0#upgrade>.
