### PR TITLE
Update Kustomization to kustomize.toolkit.fluxcd.io/v1

### DIFF
--- a/clusters/rpi/flux-system/gotk-sync.yaml
+++ b/clusters/rpi/flux-system/gotk-sync.yaml
@@ -13,7 +13,7 @@ spec:
   url: ssh://git@github.com/iamleot/rpi-flux.git
 
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: flux-system

--- a/clusters/rpi/infrastructure.yaml
+++ b/clusters/rpi/infrastructure.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: infrastructure

--- a/clusters/rpi/secrets.yaml
+++ b/clusters/rpi/secrets.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: secrets


### PR DESCRIPTION
No deprecated fields should be used so all of them should be fine as is without any adjustments.

Mechanically done via:

```console
 sed -i -e \
     '/^apiVersion:/s;kustomize.toolkit.fluxcd.io/v1beta2;kustomize.toolkit.fluxcd.io/v1;' \
     `ag -l '^kind: Kustomization'`
```

Part of updating to Flux 2.0.0.

---

Based on notes in <https://github.com/fluxcd/flux2/releases/tag/v2.0.0#upgrade>.

---

Same of commit 385e1a2d22b249c8d7ab45ad1a85bea971882206 (AKA #52) but for `Kustomization`s.
