### PR TITLE
Update to kube-prometheus-stack chart 55.5.1

### DIFF
--- a/infrastructure/kube-prometheus-stack/release.yaml
+++ b/infrastructure/kube-prometheus-stack/release.yaml
@@ -12,7 +12,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: prometheus-community
-      version: 44.2.1
+      version: 55.5.1
   install:
     crds: Create
     createNamespace: true


### PR DESCRIPTION
Update to latest kube-prometheus-stack chart version.

Changes:
55.x
This version upgrades Prometheus-Operator to v0.70.0.

54.x
Grafana Helm Chart has bumped to version 7.

53.x
This version upgrades Prometheus-Operator to v0.69.1, Prometheus to 2.47.2.

52.x
This includes the ability to select between using existing secrets or
create new secret objects for various thanos config. The defaults have
not changed but if you were setting:

- `thanosRuler.thanosRulerSpec.alertmanagersConfig` or
- `thanosRuler.thanosRulerSpec.objectStorageConfig` or
- `thanosRuler.thanosRulerSpec.queryConfig` or
- `prometheus.prometheusSpec.thanos.objectStorageConfig`

you will have to need to set `existingSecret` or `secret` based on your
requirement.

51.x
This version upgrades Prometheus-Operator to v0.68.0, Prometheus to 2.47.0 and
Thanos to v0.32.2.

50.x
This version requires Kubernetes 1.19+.

We do not expect any breaking changes in this version.

49.x
This version upgrades Prometheus-Operator to v0.67.1, 0, Alertmanager
to v0.26.0, Prometheus to 2.46.0 and Thanos to v0.32.0.

48.x
This version moved all CRDs into a dedicated sub-chart. No new CRDs are
introduced in this version. See
<https://github.com/prometheus-community/helm-charts/issues/3548> for
more context.

We do not expect any breaking changes in this version.

47.x
This version upgrades Prometheus-Operator to v0.66.0 with new CRDs
(PrometheusAgent and ScrapeConfig).

46.x
This version upgrades Prometheus-Operator to v0.65.1 with new CRDs
(PrometheusAgent and ScrapeConfig), Prometheus to v2.44.0 and Thanos
to v0.31.0.

45.x
This version upgrades Prometheus-Operator to v0.63.0, Prometheus to
v2.42.0 and Thanos to v0.30.2.
