### PR TITLE
Add telegram-bot secret

### DIFF
--- a/secrets/telegram-bot.yaml
+++ b/secrets/telegram-bot.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: telegram-bot
+    namespace: flux-system
+stringData:
+    bot_token: ENC[AES256_GCM,data:ME4y882ftKFX65UBVGaw4IaYog/ChcKlwoiTd0FesjCYSR7IhKmSp+KEbQBZTQ==,iv:b/uECEiVzKSG1iW4NTQno5GIY5uzeW663L47mgyNzRc=,tag:JA4bvwBDErvAPDjSZ+R3Fw==,type:str]
+    chat_id: ENC[AES256_GCM,data:RuPE9QB3mmZNNvk=,iv:5m99aCDEDHowHLyIv6DjKfO6jJBCzx43z39P06iB53Q=,tag:sq/FSwA0LktVXVYkEX1/xw==,type:int]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1a2e8j4zajj69sd9atf88quglm6ghhsetxhqtftfvvl7az90zmytqzyt9cc
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6QUhVK3VveTFjUXhsdHZm
+            OStvbFEyazA0RnJudlQyeFdPMksxK0tjaVRJCjFlNEtJVUVTaVg0Y3crUFJnZ2xD
+            bkt5Yk1kYjE5S3B6K1h2b2llWVR6bEUKLS0tIE5DUDV0WlFTdzBqdXJUeEFpVzRi
+            MjhkZkRHS0FGK2ZyTGl5bFlUdmUrTXcKLTUCYmu2WrnaxhgBW/dek5ZsziJkMJrF
+            gEoM65Dz6jGoyVr6XSbVrLjDNsiunPOMpBNbmb60S8hwO89Q1x63sg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2023-12-29T18:13:29Z"
+    mac: ENC[AES256_GCM,data:Z858IY086vwnTqu2NxNhgIj5xM4wfAgNFImo9QRuMq9oIQS6B6r6lQEl7wt9uJCys1vbkd3ZuHhtt2hytgZ1OkMk2u7vVkBHm5R7fclUzI6BJqyrH0yKAkZ/Cj6OIajJKj5tSd3C4z8DpczRd6pNluUBHe9PX2ubUddbp5JgHvo=,iv:7ZBuRc2cz6BO/Lfp+zxegIJd/gjFzxadFDupXq4lM3I=,tag:w4LUqqXM20ZSp0dGagu2NA==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.7.3


### PR DESCRIPTION
Contains Telegram bot token and Telegram chat ID intended to be used by Alertmanager to send notifications on Telegram.

Side-notes, in order to generate all of that:

- Bot was created by following <https://t.me/botfather?start>
- Telegram group chat was created and the bot was invited
- `shoutrrr generate telegram` was used in order to get the chat ID
