### PR TITLE
Switch to data:

### DIFF
--- a/secrets/telegram-bot.yaml
+++ b/secrets/telegram-bot.yaml
@@ -3,9 +3,9 @@ kind: Secret
 metadata:
     name: telegram-bot
     namespace: flux-system
-stringData:
-    bot_token: ENC[AES256_GCM,data:ME4y882ftKFX65UBVGaw4IaYog/ChcKlwoiTd0FesjCYSR7IhKmSp+KEbQBZTQ==,iv:b/uECEiVzKSG1iW4NTQno5GIY5uzeW663L47mgyNzRc=,tag:JA4bvwBDErvAPDjSZ+R3Fw==,type:str]
-    chat_id: ENC[AES256_GCM,data:RuPE9QB3mmZNNvk=,iv:5m99aCDEDHowHLyIv6DjKfO6jJBCzx43z39P06iB53Q=,tag:sq/FSwA0LktVXVYkEX1/xw==,type:int]
+data:
+    bot_token: ENC[AES256_GCM,data:WdLZ57V769g7X3M0eX5fUrVnEOg1aUWeizP2i59o3ByBKS00LIlrn5X6/vDB7pzr1A3Dd42YtSXkudeoLAkMtA==,iv:A783BdvyB7L9Du6oG7wQ9Si41dMXc8GhmfUNdauvTiI=,tag:f1TWOA5cP7OOjcVgI1xkdg==,type:str]
+    chat_id: ENC[AES256_GCM,data:S3v2dKy42DMEJzSIclNllQ==,iv:plczsIEVTWndn/HjMXmmfq5Ceyrgi3j0gX1iZ0tp3sQ=,tag:5AJFXJzuBhFwfGuSHmB0Kw==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -15,14 +15,14 @@ sops:
         - recipient: age1a2e8j4zajj69sd9atf88quglm6ghhsetxhqtftfvvl7az90zmytqzyt9cc
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6QUhVK3VveTFjUXhsdHZm
-            OStvbFEyazA0RnJudlQyeFdPMksxK0tjaVRJCjFlNEtJVUVTaVg0Y3crUFJnZ2xD
-            bkt5Yk1kYjE5S3B6K1h2b2llWVR6bEUKLS0tIE5DUDV0WlFTdzBqdXJUeEFpVzRi
-            MjhkZkRHS0FGK2ZyTGl5bFlUdmUrTXcKLTUCYmu2WrnaxhgBW/dek5ZsziJkMJrF
-            gEoM65Dz6jGoyVr6XSbVrLjDNsiunPOMpBNbmb60S8hwO89Q1x63sg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBbG45cVNTMFJuK05vb0J2
+            VWVJUXlHN3hNN3diN3gzVkZIZGRxc3pjdnhrCkcxZEFiUzhEcEd1UEVDMEJvY0U5
+            VUJ3MUZ3WlFxOE16d2c5dlkwYTFralEKLS0tIDA4UjhvVW91QzR3K3FWUE1EemMv
+            SVZZMkhpREE3amJYakJ2WmhMRFNrdGcKhQCOjJBzK/oaX7YpzyRYybHWKk/B4ULS
+            VyUDYFG+cGzKlXDAsGUMqfX1+sG/PCVWI66dO13BY/HvmBFU1/+npQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2023-12-29T18:13:29Z"
-    mac: ENC[AES256_GCM,data:Z858IY086vwnTqu2NxNhgIj5xM4wfAgNFImo9QRuMq9oIQS6B6r6lQEl7wt9uJCys1vbkd3ZuHhtt2hytgZ1OkMk2u7vVkBHm5R7fclUzI6BJqyrH0yKAkZ/Cj6OIajJKj5tSd3C4z8DpczRd6pNluUBHe9PX2ubUddbp5JgHvo=,iv:7ZBuRc2cz6BO/Lfp+zxegIJd/gjFzxadFDupXq4lM3I=,tag:w4LUqqXM20ZSp0dGagu2NA==,type:str]
+    lastmodified: "2023-12-29T18:21:58Z"
+    mac: ENC[AES256_GCM,data:YRFCwqes1gosSVkBm+jPDYA/7wLuAs2gkWECb/zmRzMgLk9LEULHfjjqTfSSVcRsFm2a76/i8nIALdZ0fw6a3JDFDOXdm0LDTVy9hlNPJQRa5TJOmOQEGcSE8772ssMjYN2qLf6SjXm1wS4hzic47/DH8NPkqwkpX7kWj4COLvU=,iv:FMgQG+HwuFMY3nDH5UVOP2Qd4kL7xQDTgURa/RMgnt0=,tag:Zj/G9Pnnt1GcXnbSPy7M+w==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.7.3


### PR DESCRIPTION
Use `data:` instead of `stringData:` because `chat_id:` should be treated as int, not string!

In commit 68a6074bbf576353bf6aa537d50fdae6b037e591 the secret was not applied because it failed as follows:

```
Secret/flux-system/telegram-bot validation error: cannot convert int64 to string
```

...this should fix that.
