### PR TITLE
Rotate Slack Webhook URL

### DIFF
--- a/secrets/slack-api-url.yaml
+++ b/secrets/slack-api-url.yaml
@@ -4,7 +4,7 @@ metadata:
     name: slack-api-url
     namespace: flux-system
 stringData:
-    slack_api_url: ENC[AES256_GCM,data:APnEa1OaW2CASryrZeJHIi0dSFDmYBIN6j+8m9zhjLv7JzUjpzoTCqYEZ9F3iRgOqRuXjlwizkTqXixyL0WgWtvIdRyR9d/5TVWB5quehbSx,iv:36XOiiIQ2aT+1qq+70IRxR7i31czyhHSnh3TqNTFr94=,tag:7vMTn6I2oJhI64fY/I0zOg==,type:str]
+    slack_api_url: ENC[AES256_GCM,data:6oCZDfcBlfLLPgIMBt6dVrPYF1xNDta2pDGp7vanExVv0gCbXiNFTg4nOr0t2yjID4tEHhcfegVNO3KthJo5CgtLEFTis0lN9kQFTjz1VM70,iv:p9JClZ0jr62mZuQl5pEuxzrpmtCPXy/87RGoLCuicZw=,tag:PWVanMYUAeZMc8C1WPm0iQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -20,8 +20,8 @@ sops:
             UEkvUG83Szg4OXU1UTVYSEoyR0xoaVUKUbDV+etez2LZ1EW3JS+Hi1omaiNJAdRO
             2rdD4FmaSOmOPT6D8XKOHGBzi7aRd7f3L1v13BaFsakeNgpVGzQENQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2022-09-27T12:49:07Z"
-    mac: ENC[AES256_GCM,data:lj59SHCyq7ritY1B3qf3Sz8M+J6uIpbLRwXSICrgi0N592jE7YtI2kRKM6WTdV81KKHtIhpPrhUpVnMTdgzrY+JdC5d/BVkKIWYz40cbXs/nxCEBrWfFi8POof0yD1kfkFk1EEep9wzrIY0O5jbuFD6l9VpVHWa7v7646HWLzYs=,iv:qrIdYF2V7lJ46BGUGTETKRFkRk+0PKGZ7FY8DeWoQcg=,tag:wsjK4tE5htBr6PzaN377nQ==,type:str]
+    lastmodified: "2023-12-31T13:53:22Z"
+    mac: ENC[AES256_GCM,data:mP9MG0w/nCAaaLWMwxcX7suvXkCmS2wdc66zVoHVxBpb0YF9qLQTTT0JWGN8H/wAgQR3RbNc9bEo/xOqn/N1B1g9mDJTqRuatniczXKjlhJ8CtNqkNVtGZpNe4+sSULye7TxdU0pfwo24XrbPUjbYIxXHfrGJOtIs+ZmvGRmMBU=,iv:HWCdKFmmg5ZO2MwJ9NXz6AbtqPqbSCnJRaZHdK6386o=,tag:wWBdKdnFJJn2aaO6kC5mKw==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
     version: 3.7.3


### PR DESCRIPTION
Rotate the Slack Webhook URL because it was used for some testing unrelated to RPI.
