### PR TITLE
Add initial cilium HelmRelease

### DIFF
--- a/infrastructure/cilium/kustomization.yaml
+++ b/infrastructure/cilium/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - release.yaml

--- a/infrastructure/cilium/release.yaml
+++ b/infrastructure/cilium/release.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: cilium
+  namespace: flux-system
+spec:
+  chart:
+    spec:
+      chart: cilium
+      reconcileStrategy: ChartVersion
+      sourceRef:
+        kind: HelmRepository
+        name: cilium
+      version: 1.15.3
+  install:
+    createNamespace: true
+  interval: 10m0s
+  releaseName: cilium
+  storageNamespace: kube-system
+  targetNamespace: kube-system
+  values:
+    operator:
+      replicas: 1

--- a/infrastructure/kustomization.yaml
+++ b/infrastructure/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - cilium
   - grafana
   - kube-prometheus-stack
   - loki


### PR DESCRIPTION
Cilium is an open source, cloud native solution for providing, securing, and observing network connectivity between workloads, fueled by the revolutionary Kernel technology eBPF.

Generated via:

```
flux create helmrelease cilium \
    --export \
    --release-name=cilium \
    --source=HelmRepository/cilium \
    --chart=cilium \
    --chart-version=1.15.3 \
    --interval=10m \
    --create-target-namespace \
    --target-namespace=kube-system |
awk '/targetNamespace:/ { s = $0; sub(/targetNamespace:/, "storageNamespace:", s); print s } { print }' \
    > infrastructure/cilium/release.yaml
```
