### PR TITLE
Add big FIXME comment regarding namespace

### DIFF
--- a/infrastructure/kube-prometheus-stack/kustomization.yaml
+++ b/infrastructure/kube-prometheus-stack/kustomization.yaml
@@ -2,6 +2,12 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - release.yaml
+# FIXME: This `configMapGenerator` can ends up in failing if `prometheus`
+# FIXME: namespace does not exists yet and it will need a manual
+# FIXME: `kubectl create namespace prometheus`. Unfortunately we could not
+# FIXME: create dependencies or similar because the configMap is directly
+# FIXME: consumed by the HelmRelease. To avoid that we should directly add an
+# FIXME: explicit Namespace resource picked up by the Kustomization.
 configMapGenerator:
   - name: consoles
     namespace: prometheus

--- a/infrastructure/loki/kustomization.yaml
+++ b/infrastructure/loki/kustomization.yaml
@@ -2,6 +2,12 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - release.yaml
+# FIXME: This `configMapGenerator` can ends up in failing if `loki`
+# FIXME: namespace does not exists yet and it will need a manual
+# FIXME: `kubectl create namespace loki`. Unfortunately we could not
+# FIXME: create dependencies or similar because the configMap is directly
+# FIXME: consumed by the HelmRelease. To avoid that we should directly add an
+# FIXME: explicit Namespace resource picked up by the Kustomization.
 configMapGenerator:
   - name: rules
     namespace: loki


### PR DESCRIPTION
If `loki` and/or `prometheus` namespaces do not already exist the `infrastructure` kustomization will get stuck because using configMapGenetor needs the Namespace to be present while the HelmRelease is still not yet created.
