### PR TITLE
Instruct Renovate that this is a Flux repo

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
-  ]
+  ],
+  "flux": {
+    "fileMatch": ["\\.ya?ml$"]
+  }
 }


### PR DESCRIPTION
Extend Renovate checks to all YAMLs because this is a Flux repository.

Based on documentation in <https://docs.renovatebot.com/modules/manager/flux/>.
