### PR TITLE
Add matchers for *_VERSION in GitHub Actions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,30 @@
   "extends": [
     "config:recommended"
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "\\.github/workflows/.*\\.ya?ml$"
+      ],
+      "matchStrings": [
+        "CONFTEST_VERSION:\\s+\"(?<currentValue>.*)\""
+      ],
+      "depNameTemplate": "open-policy-agent/conftest",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "\\.github/workflows/.*\\.ya?ml$"
+      ],
+      "matchStrings": [
+        "KUBECONFORM_VERSION:\\s+\"(?<currentValue>.*)\""
+      ],
+      "depNameTemplate": "yannh/kubeconform",
+      "datasourceTemplate": "github-releases"
+    }
+  ],
   "flux": {
     "fileMatch": ["\\.ya?ml$"]
   }


### PR DESCRIPTION
Add Renovate custom matchers to catch conftest and kubeconform versions in GitHub Actions workflows.
