### PR TITLE
Add "dependencies" labels to Renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,5 +29,6 @@
   ],
   "flux": {
     "fileMatch": ["\\.ya?ml$"]
-  }
+  },
+  "labels": ["dependencies"]
 }


### PR DESCRIPTION
Automatically add the "dependencies" labels to PRs opened by Renovate.
