### PR TITLE
Add matcher for KUBERNETES_VERSION

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -43,5 +43,12 @@
   "flux": {
     "fileMatch": ["\\.ya?ml$"]
   },
-  "labels": ["dependencies"]
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "description": ["Permit only patch updates for Kubernetes version"],
+      "matchDepNames": ["kubernetes/kubernetes"],
+      "matchUpdateTypes": ["patch"]
+    }
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,19 @@
       ],
       "depNameTemplate": "yannh/kubeconform",
       "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "Makefile$"
+      ],
+      "matchStrings": [
+        "KUBERNETES_VERSION\\s*=\\s+(?<currentValue>.*)"
+      ],
+      "autoReplaceStringTemplate": "{{{replace 'v' '' newValue}}}",
+      "currentValueTemplate": "v{{{currentValue}}}",
+      "depNameTemplate": "kubernetes/kubernetes",
+      "datasourceTemplate": "github-releases"
     }
   ],
   "flux": {


### PR DESCRIPTION
Add Renovate custom matcher for `KUBERNETES_VERSION` and add/delete leading "v" appropriately.

Limit the updates to only patch ones.
