### PR TITLE
Delete KUBERNETES_VERSION custom matcher

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,30 +25,10 @@
       ],
       "depNameTemplate": "yannh/kubeconform",
       "datasourceTemplate": "github-releases"
-    },
-    {
-      "customType": "regex",
-      "fileMatch": [
-        "Makefile$"
-      ],
-      "matchStrings": [
-        "KUBERNETES_VERSION\\s*=\\s+(?<currentValue>.*)"
-      ],
-      "autoReplaceStringTemplate": "{{{replace 'v' '' newValue}}}",
-      "currentValueTemplate": "v{{{currentValue}}}",
-      "depNameTemplate": "kubernetes/kubernetes",
-      "datasourceTemplate": "github-releases"
     }
   ],
   "flux": {
     "fileMatch": ["\\.ya?ml$"]
   },
-  "labels": ["dependencies"],
-  "packageRules": [
-    {
-      "description": ["Permit only patch updates for Kubernetes version"],
-      "matchDepNames": ["kubernetes/kubernetes"],
-      "matchUpdateTypes": ["patch"]
-    }
-  ]
+  "labels": ["dependencies"]
 }


### PR DESCRIPTION
Seems problematic and in the Mend dashboard we have:

> Repository problems
>
> These problems occurred while renovating this repository.
>  * Error updating branch: update failure
>

Currently I do not understand it.

Revert the custom matcher until the problem is fully understood.

This reverts commits f3c864c2bd0d7ee7fa1e36148391b416895d5bcb and 0387f8d3c3b54b865dcc942551b8b9a85c9bfb3f (both part of PR #99).
