### PR TITLE
Instruct Renovate that this is a Kubernetes repo

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,5 +30,8 @@
   "flux": {
     "fileMatch": ["\\.ya?ml$"]
   },
+  "kubernetes": {
+    "fileMatch": ["\\.ya?ml$"]
+  },
   "labels": ["dependencies"]
 }


### PR DESCRIPTION
Extend Renovate checks to all YAMLs because this is a repository containing Kubernetes resources.

Based on documentation in <https://docs.renovatebot.com/modules/manager/kubernetes/>.
