### PR TITLE
Ignore Flux's gotk-components.ya?ml

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -31,7 +31,11 @@
     "fileMatch": ["\\.ya?ml$"]
   },
   "kubernetes": {
-    "fileMatch": ["\\.ya?ml$"]
+    "fileMatch": ["\\.ya?ml$"],
+    "ignorePaths": [
+      "gotk-components.yaml",
+      "gotk-components.yml"
+    ]
   },
   "labels": ["dependencies"],
   "schedule": ["* 4 * * 3"]


### PR DESCRIPTION
Kubernetes manager also capture files that should be managed only by Flux. Ignore `gotk-components.ya?ml`, this is already handled by Flux manager.
