### PR TITLE
Add readeck

### DIFF
--- a/apps/kustomization.yaml
+++ b/apps/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - readeck

--- a/apps/readeck/ingress.yaml
+++ b/apps/readeck/ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: readeck
+  namespace: readeck
+  annotations:
+    nginx.ingress.kubernetes.io/limit-burst-multiplier: "1"
+    nginx.ingress.kubernetes.io/limit-rpm: "100"
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /readeck
+            pathType: Prefix
+            backend:
+              service:
+                name: readeck
+                port:
+                  name: http
+  ingressClassName: nginx

--- a/apps/readeck/kustomization.yaml
+++ b/apps/readeck/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ingress.yaml
+  - service.yaml
+  - statefulset.yaml

--- a/apps/readeck/service.yaml
+++ b/apps/readeck/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: readeck
+  namespace: readeck
+  labels:
+    app: readeck
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000
+  selector:
+    app: readeck

--- a/apps/readeck/statefulset.yaml
+++ b/apps/readeck/statefulset.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: readeck
+  namespace: readeck
+  labels:
+    app: readeck
+spec:
+  selector:
+    matchLabels:
+      app: readeck
+  serviceName: readeck
+  template:
+    metadata:
+      labels:
+        app: readeck
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      containers:
+        - name: readeck
+          image: codeberg.org/readeck/readeck:0.17.1
+          env:
+            - name: READECK_METRICS_PORT
+              value: "8002"
+            - name: READECK_SERVER_PREFIX
+              value: /readeck
+          ports:
+            - containerPort: 8000
+              name: http
+            - containerPort: 8002
+              name: metrics
+          volumeMounts:
+            - name: readeck
+              mountPath: /readeck
+          livenessProbe:
+            tcpSocket:
+              port: 8000
+          readinessProbe:
+            tcpSocket:
+              port: 8000
+  volumeClaimTemplates:
+    - metadata:
+        name: readeck
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 5Gi

--- a/clusters/rpi/apps.yaml
+++ b/clusters/rpi/apps.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: apps
+  namespace: flux-system
+spec:
+  interval: 10m0s
+  path: ./apps
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system


### PR DESCRIPTION
Readeck is a simple web application that lets you save the precious readable content of web pages you like and want to keep forever.

Add initial StatefulSet and Service and populate them in the apps Flux Kustomization (that will be hooked in a separate commit).

:warning: Still WIP, see the following TODOs:

- [x] Drop privileges and run as non-root user
- [x] Add healthchecks
- [x] Check if it exposes Prometheus metrics, if yes collect them
- [x] Test deletion/addition of the StatefulSet and double-check that the volume persist and can be reused

Outside the scope for this PR:

- Define an `Ingress` so this can be exposed
- Figure out how to add `readeck` Namespace (it was manually created via `kubectl create namespace readeck`)