### PR TITLE
Add ingress-nginx

### DIFF
--- a/infrastructure/ingress-nginx/kustomization.yaml
+++ b/infrastructure/ingress-nginx/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - release.yaml

--- a/infrastructure/ingress-nginx/release.yaml
+++ b/infrastructure/ingress-nginx/release.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ingress-nginx
+  namespace: flux-system
+spec:
+  values:
+    controller:
+      metrics:
+        enabled: true
+        prometheusRule:
+          enabled: true
+          namespace: prometheus
+          additionalLabels:
+            release: kube-prometheus-stack
+          rules:
+            - alert: NGINXDown
+              annotations:
+                description: >
+                  NGINX Ingress Controller disappeared from Prometheus target
+                  discovery.
+                summary: >
+                  NGINX Ingress Controller disappeared from Prometheus target
+                  discovery.
+              expr: absent(up{job="ingress-nginx-controller-metrics"})
+              for: 15m
+              labels:
+                severity: critical
+            - alert: NGINXConfigFailed
+              annotations:
+                description: >
+                  NGINX Ingress Controller configuration could not be loaded.
+                summary: NGINX Ingress Controller configuration is invalid.
+              expr: count(nginx_ingress_controller_config_last_reload_successful == 0) > 0
+              for: 1m
+              labels:
+                severity: warning
+            - alert: NGINXCertificateExpiry
+              annotations:
+                description: >
+                  SSL certificate(s) will expire in less then a week.
+                summary: Expiring SSL certificate(s).
+              expr: (avg(nginx_ingress_controller_ssl_expire_time_seconds{host!="_"}) by (host) - time()) < 604800
+              for: 1m
+              labels:
+                severity: warning
+        serviceMonitor:
+          enabled: true
+          namespace: prometheus
+          additionalLabels:
+            release: kube-prometheus-stack
+          namespaceSelector:
+            matchNames:
+              - ingress-nginx
+      service:
+        externalTrafficPolicy: Local
+  chart:
+    spec:
+      chart: ingress-nginx
+      sourceRef:
+        kind: HelmRepository
+        name: ingress-nginx
+        namespace: flux-system
+      version: 4.12.0
+  install:
+    createNamespace: true
+  interval: 10m0s
+  releaseName: ingress-nginx
+  storageNamespace: ingress-nginx
+  targetNamespace: ingress-nginx

--- a/infrastructure/kustomization.yaml
+++ b/infrastructure/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - grafana
+  - ingress-nginx
   - kube-prometheus-stack
   - loki
   - metrics-server


### PR DESCRIPTION
Add Ingress NGINX Controller. Provides an Ingress implementation.

Also enable the scraping of Prometheus metrics and add some custom alerts.

`NGINXConfigFailed` and `NGINXCertificateExpiry` are based on the ones present in the official Helm values as comments.

`NGINXDown` is inspired by "Absent Alerting for Jobs" from Brian Brazil <https://www.robustperception.io/absent-alerting-for-jobs/>.
