### PR TITLE
Revert back to loki Helm release version 3.10.0

### DIFF
--- a/infrastructure/loki/release.yaml
+++ b/infrastructure/loki/release.yaml
@@ -12,7 +12,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: grafana
-      version: 6.27.0
+      version: 3.10.0
   install:
     createNamespace: true
   interval: 10m0s


### PR DESCRIPTION
Helm reconciliation fails with:

> Reconciler error execution error at (loki/templates/validate.yaml:19:4): Cannot run scalable targets (backend, read, write) or distributed targets without an object storage backend.

We need to figure out how to run it as it was with 3.x.

This reverts commit d03515d8154244eed0860a04299bea03e5fe1838.
