### PR TITLE
Permit to send bigger requests

### DIFF
--- a/apps/readeck/ingress.yaml
+++ b/apps/readeck/ingress.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/limit-burst-multiplier: "1"
     nginx.ingress.kubernetes.io/limit-rpm: "100"
+    nginx.ingress.kubernetes.io/proxy-body-size: 4m
 spec:
   rules:
     - http:


### PR DESCRIPTION
When using Readeck browser addon the complete HTML page with all the data is sent and it is easy to reach default limit of 1m.

Bump to 4m to send bigger requests.
