### PR TITLE
Add victoriametrics HelmRepository

### DIFF
--- a/infrastructure/sources/kustomization.yaml
+++ b/infrastructure/sources/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - ingress-nginx.yaml
   - metrics-server.yaml
   - prometheus-community.yaml
+  - victoriametrics.yaml

--- a/infrastructure/sources/victoriametrics.yaml
+++ b/infrastructure/sources/victoriametrics.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: victoriametrics
+  namespace: flux-system
+spec:
+  interval: 6h0m0s
+  url: https://victoriametrics.github.io/helm-charts/


### PR DESCRIPTION
Needed to install victoria-logs-single Helm release.
