### PR TITLE
Add victorialogs

### DIFF
--- a/infrastructure/kustomization.yaml
+++ b/infrastructure/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - metrics-server
   - promtail
   - sources
+  - victorialogs

--- a/infrastructure/victorialogs/kustomization.yaml
+++ b/infrastructure/victorialogs/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - release.yaml

--- a/infrastructure/victorialogs/release.yaml
+++ b/infrastructure/victorialogs/release.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: victorialogs
+  namespace: flux-system
+spec:
+  values:
+    server:
+      persistentVolume:
+        size: 5Gi
+      retentionDiskSpaceUsage: 5GB
+      retentionPeriod: 7d
+      serviceMonitor:
+        enabled: true
+        extraLabels:
+          release: kube-prometheus-stack
+  chart:
+    spec:
+      chart: victoria-logs-single
+      sourceRef:
+        kind: HelmRepository
+        name: victoriametrics
+        namespace: flux-system
+      version: 0.11.5
+  install:
+    createNamespace: true
+  interval: 10m0s
+  releaseName: victorialogs
+  storageNamespace: victorialogs
+  targetNamespace: victorialogs


### PR DESCRIPTION
Add VictoriaLogs configured as a single node.

Intended to replace Loki that is much more complex to manage and for RPI use case probably less suitable.

Mostly the default configuration - VictoriaLogs do not need any special configuration and defaults are sane - except the adjustment to use a 5Gi volume (instead of default of 10Gi) and lower down the retention period and adjust the retention disk space usage too according the volume size.

A corresponding serviceMonitor so that it is monitored by Prometheus is also enabled.

In the first iteration promtail will be used to ingest logs, this will be done in a separate commit later.
Probably we should investigate Vector - maybe deployed as a separate Helm release - that it is used by default and can be enabled also in the victoria-logs-single Helm chart.
