### PR TITLE
Stop log ingestion to Loki

### DIFF
--- a/infrastructure/promtail/release.yaml
+++ b/infrastructure/promtail/release.yaml
@@ -22,7 +22,6 @@ spec:
   values:
     config:
       clients:
-        - url: http://loki.loki.svc.cluster.local:3100/loki/api/v1/push
         - url: http://victorialogs-victoria-logs-single-server.victorialogs.svc.cluster.local:9428/insert/loki/api/v1/push
     serviceMonitor:
       enabled: true


### PR DESCRIPTION
Loki will be replaced with VictoriaLogs so stop ingesting logs to it.
