### PR TITLE
Add vector HelmRepository

### DIFF
--- a/infrastructure/sources/kustomization.yaml
+++ b/infrastructure/sources/kustomization.yaml
@@ -5,4 +5,5 @@ resources:
   - ingress-nginx.yaml
   - metrics-server.yaml
   - prometheus-community.yaml
+  - vector.yaml
   - victoriametrics.yaml

--- a/infrastructure/sources/vector.yaml
+++ b/infrastructure/sources/vector.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: vector
+  namespace: flux-system
+spec:
+  interval: 6h0m0s
+  url: https://helm.vector.dev


### PR DESCRIPTION
Needed for Vector. Intended to replace promtail that is no longer supported.
