### PR TITLE
Properly set msg and stream fields

### DIFF
--- a/infrastructure/vector/release.yaml
+++ b/infrastructure/vector/release.yaml
@@ -47,9 +47,9 @@ spec:
             - parser
           type: elasticsearch
           query:
-            _msg_field: message
+            _msg_field: message,msg,_msg,log.msg,log.message,log
             _time_field: timestamp
-            _stream_fields: host,container_name
+            _stream_fields: stream,kubernetes.pod_name,kubernetes.container_name,kubernetes.pod_namespace
   chart:
     spec:
       chart: vector


### PR DESCRIPTION
Actually honor the msg and stream that are defined in VictoriaLogs Helm chart. Otherwise the stream ends up null!

Now logs should be acceptable.
