### PR TITLE
Manually define the PodMonitor

### DIFF
--- a/infrastructure/vector/kustomization.yaml
+++ b/infrastructure/vector/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - podmonitor.yaml
   - release.yaml

--- a/infrastructure/vector/podmonitor.yaml
+++ b/infrastructure/vector/podmonitor.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: vector
+  namespace: vector
+  labels:
+    release: kube-prometheus-stack
+spec:
+  namespaceSelector:
+    matchNames:
+      - vector
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: vector
+  podMetricsEndpoints:
+    - portNumber: 9090

--- a/infrastructure/vector/release.yaml
+++ b/infrastructure/vector/release.yaml
@@ -7,10 +7,6 @@ metadata:
 spec:
   values:
     role: Agent
-    podMonitor:
-      enabled: true
-      additionalLabels:
-        release: kube-prometheus-stack
     customConfig:
       data_dir: /vector-data-dir
       api:


### PR DESCRIPTION
Actually use the portNumber so Prometheus is able to scrape Vector metrics.

(By trying `port: exporter` in the Helm chart I still was not able to scrape it... and there are no way to specify the port number... This seems broken by default and should be investigated further!)

Closes issue #140.
