### PR TITLE
Add coredns-custom ConfigMap

### DIFF
--- a/infrastructure/coredns/configmap.yaml
+++ b/infrastructure/coredns/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns-custom
+  namespace: kube-system
+data:
+  empty.override: |
+    # Silence warnings due <https://github.com/coredns/coredns/issues/3600>
+  empty.server: |
+    # Silence warnings due <https://github.com/coredns/coredns/issues/3600>

--- a/infrastructure/coredns/kustomization.yaml
+++ b/infrastructure/coredns/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - configmap.yaml

--- a/infrastructure/kustomization.yaml
+++ b/infrastructure/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - coredns
   - grafana
   - ingress-nginx
   - kube-prometheus-stack


### PR DESCRIPTION
Add empty `*.override` and `*.server` files in order to silence the following WARNINGs in coredns:

```
[WARNING] No files matching import glob pattern: /etc/coredns/custom/*.override
[WARNING] No files matching import glob pattern: /etc/coredns/custom/*.server
```

They are repeated every 35 seconds and are very annoying.

Please read <https://github.com/coredns/coredns/issues/3600> for more information/background.
