### PR TITLE
Install victoriametrics-logs-datasource plugin

### DIFF
--- a/infrastructure/grafana/release.yaml
+++ b/infrastructure/grafana/release.yaml
@@ -38,3 +38,5 @@ spec:
       datasources:
         enabled: true
         searchNamespace: ALL
+    plugins:
+      - victoriametrics-logs-datasource


### PR DESCRIPTION
Install plugin needed in order to use VictoriaLogs as a datasource.

Sidecar can only handle plugin configuration, not installation!
