### PR TITLE
Add WeeklyTestAlert

### DIFF
--- a/infrastructure/kube-prometheus-stack/kustomization.yaml
+++ b/infrastructure/kube-prometheus-stack/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - prometheusrule.yaml
   - release.yaml
 # FIXME: This `configMapGenerator` can ends up in failing if `prometheus`
 # FIXME: namespace does not exists yet and it will need a manual

--- a/infrastructure/kube-prometheus-stack/prometheusrule.yaml
+++ b/infrastructure/kube-prometheus-stack/prometheusrule.yaml
@@ -1,0 +1,22 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: weekly-test-alert
+  namespace: prometheus
+  labels:
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: weekly-test-alert
+      rules:
+        - alert: WeeklyTestAlert
+          annotations:
+            description: >
+              Weekly test alert to double-check that alerting works.
+              If you are reading it everything is working and you can
+              ignore it.
+            summary: Weekly test alert to double-check alerting.
+          expr: (day_of_week() == 2 and hour() == 18 and minute() >= 30) > 0
+          for: 5m
+          labels:
+            severity: none


### PR DESCRIPTION
Add an alert that triggers every Tuesday from 18:30 to 19:00 UTC to exercise Alertmanager.

Severity is set to `none` instead of `info` - like Watchdog alert - in order to possibly bypass InfoInhibitor alert that can inhibit `info` alerts.

Idea completely stolen from SourceHut monitoring tools <https://git.sr.ht/~sircmpwn/metrics.sr.ht>.
