### PR TITLE
Add a discord receiver for Alertmanager

### DIFF
--- a/infrastructure/kube-prometheus-stack/release.yaml
+++ b/infrastructure/kube-prometheus-stack/release.yaml
@@ -22,11 +22,17 @@ spec:
   targetNamespace: prometheus
   upgrade:
     crds: CreateReplace
+  # XXX: Double-check the order of the targetPath defined here and in
+  # XXX: spec.valuesFrom!
   valuesFrom:
     - kind: Secret
       name: slack-api-url
       valuesKey: slack_api_url
       targetPath: alertmanager.config.global.slack_api_url
+    - kind: Secret
+      name: discord-webhook-url
+      valuesKey: discord_webhook_url
+      targetPath: alertmanager.config.receivers[1].discord_configs[0].webhook_url
   values:
     alertmanager:
       config:
@@ -40,9 +46,27 @@ spec:
             - receiver: 'null'
               matchers:
                 - alertname =~ "InfoInhibitor|Watchdog"
+            - receiver: 'discord'
+              continue: true
             - receiver: 'slack'
+              continue: true
+        # XXX: Double-check the order of the receivers defined here and in
+        # XXX: spec.valuesFrom!
         receivers:
           - name: 'null'
+          - name: 'discord'
+            discord_configs:
+              - send_resolved: true
+                title: '[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }}{{ if .CommonLabels.job }} for {{ .CommonLabels.job }}{{end}}'
+                message: |-
+                  {{ range .Alerts }}
+                    **Alert:** {{ .Annotations.summary }} - `{{ .Labels.severity }}`
+                    **Description:** {{ .Annotations.description }}
+                    **Status:** {{ .Status }}
+                    **Details:**
+                    {{ range .Labels.SortedPairs }} • **{{ .Name }}:** `{{ .Value }}`
+                    {{ end }}
+                  {{ end }}
           - name: 'slack'
             slack_configs:
               - send_resolved: true


### PR DESCRIPTION
Define another receiver via Discord so that Slack is not a single point of failure.

This was tested via:

```
 kubectl exec -n prometheus alertmanager-kube-prometheus-stack-alertmanager-0 -- \
     amtool alert add TestAlert severity=none \
          --annotation=description='Test alert description' \
          --annotation=summary='Test alert summary' \
          --alertmanager.url=http://localhost:9093
```
