### PR TITLE
Update to Readeck 0.19.2

### DIFF
--- a/apps/readeck/statefulset.yaml
+++ b/apps/readeck/statefulset.yaml
@@ -22,7 +22,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: readeck
-          image: codeberg.org/readeck/readeck:0.17.1
+          image: codeberg.org/readeck/readeck:0.19.2
           env:
             - name: READECK_METRICS_PORT
               value: "8002"


### PR DESCRIPTION
For a complete changelog please see:

- 0.19: <https://readeck.org/en/blog/202505-readeck-19/>
- 0.18: <https://readeck.org/en/blog/202503-readeck-18/>

The breaking changes are:

- All API tokens have changed
- Application password are replaced by API tokens, in places where there are user and password combination only the password is needed and the API token used as password (username is ignored)
