### PR TITLE
Delete no longer used CURL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 .POSIX:
 
-CURL = curl
 KUBERNETES_VERSION = 1.32.5
 KUBECONFORM = kubeconform
 KUBECONFORM_FLAGS = -strict -kubernetes-version $(KUBERNETES_VERSION) -schema-location default -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' -skip CustomResourceDefinition -verbose


### PR DESCRIPTION
Since commit 464b74c9903312c2374b242c35f670690846ab07 we are using datreeio CRDs catalog and curl is no longer needed.
