### PR TITLE
Update Helm release kube-prometheus-stack to v76.4.0

### DIFF
--- a/infrastructure/kube-prometheus-stack/release.yaml
+++ b/infrastructure/kube-prometheus-stack/release.yaml
@@ -12,7 +12,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: prometheus-community
-      version: 75.12.0
+      version: 76.4.0
   install:
     crds: Create
     createNamespace: true


### PR DESCRIPTION
There should be no breaking changes.
